### PR TITLE
Replace custom user model with profile linked to auth user

### DIFF
--- a/Journal/user/forms.py
+++ b/Journal/user/forms.py
@@ -1,24 +1,36 @@
 from django import forms
-from .models import User
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm, PasswordResetForm as DjangoPasswordResetForm
 
-class LoginForm(forms.ModelForm):
-    class Meta:
-        model = User
-        fields = ['username', 'password']
+from .models import Profile
+
+
+class LoginForm(AuthenticationForm):
+    """Authentication form bound to the configured user model."""
+
 
 class SignUpForm(UserCreationForm):
+    email = forms.EmailField(required=True)
+
     class Meta:
-        model = User
-        fields = ['username', 'email', 'password1', 'password2']
+        model = get_user_model()
+        fields = ["username", "email", "password1", "password2"]
 
-class PasswordResetForm(forms.Form):
-    email = forms.EmailField()
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.email = self.cleaned_data["email"]
+        if commit:
+            user.save()
+        return user
 
+
+class ProfileForm(forms.ModelForm):
+    class Meta:
+        model = Profile
+        fields = ["bio", "location", "birth_date", "hobbies"]
+
+
+class PasswordResetForm(DjangoPasswordResetForm):
     def __init__(self, *args, **kwargs):
-        super(PasswordResetForm, self).__init__(*args, **kwargs)
-        self.fields['email'].widget.attrs['placeholder'] = 'Enter your email'
-
-    class Meta:
-        model = User
-        fields = ['email']
+        super().__init__(*args, **kwargs)
+        self.fields["email"].widget.attrs.setdefault("placeholder", "Enter your email")

--- a/Journal/user/migrations/0002_profile_cleanup.py
+++ b/Journal/user/migrations/0002_profile_cleanup.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("user", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name="User",
+            new_name="Profile",
+        ),
+        migrations.RemoveField(
+            model_name="profile",
+            name="email",
+        ),
+        migrations.RemoveField(
+            model_name="profile",
+            name="password",
+        ),
+        migrations.RemoveField(
+            model_name="profile",
+            name="username",
+        ),
+        migrations.AlterField(
+            model_name="profile",
+            name="user",
+            field=models.OneToOneField(
+                on_delete=models.CASCADE,
+                related_name="profile",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+    ]

--- a/Journal/user/models.py
+++ b/Journal/user/models.py
@@ -1,19 +1,21 @@
+from django.conf import settings
 from django.db import models
-from django.contrib.auth.models import User
 
 
-# User model
-class User(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE)
+class Profile(models.Model):
+    """Stores additional information about an authenticated user."""
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="profile",
+    )
     bio = models.TextField(max_length=500, blank=True)
     location = models.CharField(max_length=30, blank=True)
     birth_date = models.DateField(null=True, blank=True)
     hobbies = models.CharField(max_length=100, blank=True)
-    username = models.CharField(max_length=30, unique=True)
-    email = models.EmailField(max_length=254, unique=True)
-    password = models.CharField(max_length=128)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return self.user.username
+        return self.user.get_username()


### PR DESCRIPTION
## Summary
- replace the custom `user.models.User` with a profile model that attaches to `settings.AUTH_USER_MODEL`
- update user forms to rely on the configured auth model and expose a profile form for optional fields
- add a migration that renames the legacy table and removes duplicated credential fields

## Testing
- `python manage.py migrate`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68d0142614c8832180095e652031b132