### PR TITLE
Fix Entries serializer to use Entry model

### DIFF
--- a/Journal/entries/serializers.py
+++ b/Journal/entries/serializers.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
-from .models import Entries, Tag, EntryReminder
+from .models import Entry, Tag, EntryReminder
 
 class EntriesSerializer(serializers.ModelSerializer):
     user = serializers.StringRelatedField(read_only=True) # Username 
-    tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name', queryset=Tag.objects.all())
+    tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field='name')
     class Meta:
-        model = Entries
+        model = Entry
         fields = ['id', 'user', 'title', 'content',  'tags', 'created_at', 'updated_at']
 
 class TagSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Summary
- update the entries serializer to import and reference the Entry model instead of Entries
- remove the queryset from the read-only tag field so the serializer can initialize

## Testing
- python Journal/manage.py shell -c "from entries.serializers import EntriesSerializer; EntriesSerializer()"

------
https://chatgpt.com/codex/tasks/task_e_68d01428400083218a8e33b67c52ed45