### PR TITLE
Refactor database configuration

### DIFF
--- a/Journal/Journal/settings.py
+++ b/Journal/Journal/settings.py
@@ -32,7 +32,10 @@ DEBUG = False
 ALLOWED_HOSTS = ['ThoughtFlow.onrender.com', '127.0.0.1', 'localhost']
 
 DATABASES = {
-    'default': dj_database_url.config(default=os.environ.get('DATABASE_URL'))
+    # Defaults to the local SQLite database when DATABASE_URL isn't provided.
+    'default': dj_database_url.config(
+        default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}",
+    )
 }
 
 
@@ -90,16 +93,9 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'Thought',         # Database name
-        'USER': 'zaki',     # Username you created
-        'PASSWORD': 'your_password', # Password you set
-        'HOST': 'localhost',          # Or your server IP
-        'PORT': '5432',                   # Default port 5432
-    }
-}
+# To use PostgreSQL (or another database engine), add a DATABASE_URL entry to your
+# .env file. For example:
+# DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/DB_NAME
 
 
 # Password validation


### PR DESCRIPTION
## Summary
- consolidate database configuration into a single DATABASES block
- default to local SQLite while allowing DATABASE_URL overrides via environment variables
- document how to configure PostgreSQL credentials through the .env file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0142b8388832198199c0c9c2e30f7