### PR TITLE
Fix multi-delete handling and add tests

### DIFF
--- a/Journal/entries/tests.py
+++ b/Journal/entries/tests.py
@@ -1,3 +1,45 @@
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .forms import MultiDeleteForm
+from .models import Entry
+
+
+class MultiDeleteViewTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username='tester', password='testpass123'
+        )
+
+    def test_get_renders_multi_delete_form(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse('entries:multi_delete'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('form', response.context)
+        self.assertIsInstance(response.context['form'], MultiDeleteForm)
+
+    def test_post_deletes_selected_entries_and_sets_message(self):
+        self.client.force_login(self.user)
+        entry_one = Entry.objects.create(
+            user=self.user, title='Entry One', content='Content One'
+        )
+        entry_two = Entry.objects.create(
+            user=self.user, title='Entry Two', content='Content Two'
+        )
+
+        response = self.client.post(
+            reverse('entries:multi_delete'),
+            {'selections': [entry_one.pk, entry_two.pk]},
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse('entries:view_all_entries'))
+        self.assertFalse(
+            Entry.objects.filter(pk__in=[entry_one.pk, entry_two.pk]).exists()
+        )
+        messages = [message.message for message in get_messages(response.wsgi_request)]
+        self.assertIn('Deleted 2 entries successfully.', messages)

--- a/Journal/entries/urls.py
+++ b/Journal/entries/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('<int:entry_id>/update/', views.update_entry, name='update_entry'),
     path('<int:entry_id>/delete/', views.delete_entry, name='delete_entry'),
     path('search/', views.search_entries, name='search_entries'),
+    path('multi-delete/', views.multi_delete, name='multi_delete'),
 ]

--- a/Journal/entries/views.py
+++ b/Journal/entries/views.py
@@ -105,7 +105,7 @@ def multi_delete(request):
             count = selected.count()
             selected.delete()
             messages.success(request, f'Deleted {count} entries successfully.')
-            return redirect('entries:all_entries')
+            return redirect('entries:view_all_entries')
     else:
         form = MultiDeleteForm()
 


### PR DESCRIPTION
## Summary
- ensure the multi-delete view uses the corrected cleaned-data lookup, renders the form on GET, and redirects to the all entries page after deletion
- expose the multi-delete view through the entries URL configuration
- add regression tests covering multi-delete GET rendering and successful POST deletion with messaging

## Testing
- SECRET_KEY=test-secret python manage.py test entries

------
https://chatgpt.com/codex/tasks/task_e_68d0171f3b68832192144d768396c62b