### PR TITLE
Align password reset templates

### DIFF
--- a/user/templates/password_reset_email.html
+++ b/user/templates/password_reset_email.html
@@ -1,0 +1,9 @@
+{% load i18n %}
+{% autoescape off %}
+<p>{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}</p>
+<p>{% blocktrans %}Please go to the following page and choose a new password:{% endblocktrans %}</p>
+<p><a href="{{ protocol }}://{{ domain }}{% url 'user:password_reset_confirm' uidb64=uid token=token %}">{% trans "Reset your password" %}</a></p>
+<p>{% blocktrans %}Your username, in case you've forgotten: {{ user.get_username }}{% endblocktrans %}</p>
+<p>{% trans "Thanks for using our site!" %}</p>
+<p>{% blocktrans %}The {{ site_name }} team{% endblocktrans %}</p>
+{% endautoescape %}

--- a/user/templates/password_reset_subject.txt
+++ b/user/templates/password_reset_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% blocktrans %}Reset your {{ site_name }} password{% endblocktrans %}

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import path, include, reverse_lazy
 from . import views
 from django.contrib.auth import views as auth_views
 from .views import SignupView
@@ -18,22 +18,24 @@ urlpatterns = [
          auth_views.PasswordResetView.as_view(
              template_name='password_reset.html',
              email_template_name='password_reset_email.html',
-             subject_template_name='password_reset_subject.txt'
+             subject_template_name='password_reset_subject.txt',
+             success_url=reverse_lazy('user:password_reset_done')
          ),
          name='password_reset'),
     path('password-reset/done/',
          auth_views.PasswordResetDoneView.as_view(
-             template_name='registration/password_reset_done.html'
+             template_name='password_reset_done.html'
          ),
          name='password_reset_done'),
     path('password-reset-confirm/<uidb64>/<token>/',
          auth_views.PasswordResetConfirmView.as_view(
-             template_name='registration/password_reset_confirm.html'
+             template_name='password_reset_confirm.html',
+             success_url=reverse_lazy('user:password_reset_complete')
          ),
          name='password_reset_confirm'),
     path('password-reset-complete/',
          auth_views.PasswordResetCompleteView.as_view(
-             template_name='registration/password_reset_complete.html'
+             template_name='password_reset_complete.html'
          ),
          name='password_reset_complete'),
 ]


### PR DESCRIPTION
## Summary
- point password reset views to in-app templates for every step of the flow
- add subject and email templates for password reset notifications
- ensure confirm view redirects succeed by specifying explicit success URLs

## Testing
- `python manage.py shell <<'PY'`

------
https://chatgpt.com/codex/tasks/task_e_68d053fda20c8321baa73412588920d9

## Summary by Sourcery

Align the user password reset flow to use custom in-app templates, introduce dedicated email and subject templates, and add explicit success URL redirects at each step

New Features:
- Use in-app templates for password reset, done, confirm, and complete views
- Add custom email body and subject templates for password reset notifications

Enhancements:
- Specify explicit success_url parameters for the password reset request and confirm views