### PR TITLE
Fix search form and view integration

### DIFF
--- a/entries/forms.py
+++ b/entries/forms.py
@@ -47,11 +47,14 @@ class UpdateEntryForm(EntryForm):
         self.fields['tags'].queryset = self.fields['tags'].queryset.order_by('name')
 
 class SearchForm(forms.Form):
-    q = forms.CharField(label='Search', max_length=100, required=False)
-    label = '',
-    widgets = {
-        'q': forms.TextInput(attrs={'class' : 'form-control', 'placeholder': 'Search for an entry'})
-    }
+    query = forms.CharField(
+        label='',
+        max_length=100,
+        required=False,
+        widget=forms.TextInput(
+            attrs={'class': 'form-control', 'placeholder': 'Search for an entry'}
+        ),
+    )
 
 class MultiDeleteForm(forms.Form):
     selections = forms.ModelMultipleChoiceField(queryset=Entry.objects.all(), widget=forms.CheckboxSelectMultiple)

--- a/entries/templates/entries/search_entries.html
+++ b/entries/templates/entries/search_entries.html
@@ -10,7 +10,7 @@
                 </div>
                 
                 <div class="card-body p-4">
-                    <form method="get" action="{% url 'journal:search' %}">
+                    <form method="get" action="{% url 'entries:search_entries' %}">
                         <div class="input-group mb-4">
                             {{ form.query }}
                             <button class="btn btn-auth-primary" type="submit">
@@ -31,7 +31,7 @@
                                         <small>{{ entry.created_at|date:"M d, Y" }}</small>
                                     </div>
                                     <p class="mb-1">{{ entry.content|truncatewords:20 }}</p>
-                                    <a href="{% url 'journal:entry_detail' entry.id %}" class="text-warning">Read more</a>
+                                    <a href="{% url 'entries:view_entry' entry.id %}" class="text-warning">Read more</a>
                                 </div>
                                 {% endfor %}
                             </div>

--- a/entries/views.py
+++ b/entries/views.py
@@ -77,21 +77,25 @@ from .models import Entry
 from .forms import SearchForm
 
 def search_entries(request):
-    form = SearchForm()
+    form = SearchForm(request.GET or None)
     results = []
-    q = None
-    
-    if 'query' in request.GET:
-        form = SearchForm(request.GET)
-        if form.is_valid():
-            query = form.cleaned_data['q']
+    query = ''
+
+    if form.is_valid():
+        query = form.cleaned_data['query']
+        if query:
             results = Entry.objects.filter(
-                Q(title__icontains=query) | 
+                Q(title__icontains=query) |
                 Q(content__icontains=query)
             )
-            q = query
-    
-    return render(request, 'entries/search_entries.html', {'form': form, 'results': results, 'q': q})
+
+    context = {
+        'form': form,
+        'results': results,
+        'query': query,
+    }
+
+    return render(request, 'entries/search_entries.html', context)
 
 from .forms import MultiDeleteForm
 from django.contrib import messages


### PR DESCRIPTION
## Summary
- align the search form field name with the template and view
- update the search view to validate GET parameters and filter entries reliably
- point the search template to the correct URL names for submission and entry links

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68d055b6a27c83218bf70da7f909548d