### PR TITLE
Fix namespace includes for app URLs

### DIFF
--- a/Journal/urls.py
+++ b/Journal/urls.py
@@ -21,7 +21,7 @@ from django.contrib.auth import views as auth_views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('user/login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),
-    path('', include('entries.urls')),
-    path('', include('user.urls')),
+    path('', include('entries.urls', namespace='entries')),
+    path('', include('user.urls', namespace='user')),
     path('social-auth/', include('social_django.urls', namespace='social')),
 ]


### PR DESCRIPTION
## Summary
- update the root URL configuration to include the entries and user apps with their namespaces so reverse lookups like `entries:update_entry` and `user:login` resolve correctly

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68d0568287b8832180f7924b4bdd7c04

## Summary by Sourcery

Bug Fixes:
- Include 'entries' and 'user' namespaces in the root URL configuration for URL pattern includes