### PR TITLE
Restrict entry access to owners

### DIFF
--- a/entries/forms.py
+++ b/entries/forms.py
@@ -57,4 +57,14 @@ class SearchForm(forms.Form):
     )
 
 class MultiDeleteForm(forms.Form):
-    selections = forms.ModelMultipleChoiceField(queryset=Entry.objects.all(), widget=forms.CheckboxSelectMultiple)
+    selections = forms.ModelMultipleChoiceField(
+        queryset=Entry.objects.none(),
+        widget=forms.CheckboxSelectMultiple(),
+    )
+
+    def __init__(self, *args, user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if user is not None:
+            self.fields['selections'].queryset = Entry.objects.filter(user=user)
+        else:
+            self.fields['selections'].queryset = Entry.objects.none()

--- a/entries/tests.py
+++ b/entries/tests.py
@@ -1,3 +1,79 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Entry
+
+
+class EntryPermissionsTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username='alice',
+            password='password123',
+        )
+        self.other_user = user_model.objects.create_user(
+            username='bob',
+            password='password123',
+        )
+
+        self.entry = Entry.objects.create(
+            user=self.user,
+            title='Alice Entry',
+            content='Shared content keyword',
+        )
+        self.other_entry = Entry.objects.create(
+            user=self.other_user,
+            title='Bob Entry',
+            content='Shared content keyword',
+        )
+
+    def test_view_entry_other_user_returns_404(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(
+            reverse('entries:view_entry', args=[self.other_entry.id])
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_view_all_entries_only_returns_user_entries(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(reverse('entries:view_all_entries'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context['entries']), [self.entry])
+
+    def test_search_entries_excludes_other_users_entries(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(
+            reverse('entries:search_entries'),
+            {'query': 'shared'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(list(response.context['results']), [self.entry])
+
+    def test_delete_entry_other_user_returns_404(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse('entries:delete_entry', args=[self.other_entry.id])
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(Entry.objects.filter(id=self.other_entry.id).exists())
+
+    def test_multi_delete_cannot_remove_other_users_entries(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse('entries:multi_delete'),
+            {'selections': [self.entry.id, self.other_entry.id]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Entry.objects.filter(id=self.other_entry.id).exists())
+        self.assertTrue(Entry.objects.filter(id=self.entry.id).exists())

--- a/entries/urls.py
+++ b/entries/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('<int:entry_id>/update/', views.update_entry, name='update_entry'),
     path('<int:entry_id>/delete/', views.delete_entry, name='delete_entry'),
     path('search/', views.search_entries, name='search_entries'),
+    path('delete/multiple/', views.multi_delete, name='multi_delete'),
 ]


### PR DESCRIPTION
## Summary
- require authentication and filter entry views/actions to the signed-in user's records
- restrict the bulk delete form/queryset to the current user and expose the view at a dedicated URL
- add regression tests ensuring users cannot view, search, or delete entries they do not own

## Testing
- python manage.py test entries

------
https://chatgpt.com/codex/tasks/task_e_68d05814420c8321aeb6cbf8bddf8ab3

## Summary by Sourcery

Enforce per-user entry access by requiring authentication on all entry views, filtering querysets to the current user, expose a dedicated bulk-delete endpoint, and add tests to block cross-user operations.

New Features:
- Add dedicated multi-delete endpoint for bulk entry deletion at delete/multiple/.

Bug Fixes:
- Prevent users from viewing, listing, searching, or deleting entries belonging to other users.

Enhancements:
- Require login on all entry-related views and filter entry querysets to the current user.
- Filter bulk delete form choices to the current user's entries.

Tests:
- Add regression tests to verify users cannot view, search, or delete entries they do not own.