### PR TITLE
Fix entry context references in templates

### DIFF
--- a/entries/templates/entries/home.html
+++ b/entries/templates/entries/home.html
@@ -22,9 +22,9 @@
             <!-- Entries List  
             <div class="card shadow-sm">
                 <div class="card-body p-0">
-                    {% if Entry %}
+                    {% if entries %}
                     <ul class="list-group list-group-flush">
-                        {% for entry in Entry %}
+                        {% for entry in entries %}
                         <li class="list-group-item d-flex justify-content-between align-items-center py-3">
                             <a href="{% url 'entries:view_entry' entry.id %}" class="text-decoration-none flex-grow-1">
                                 <h5 class="mb-1">{{ entry.title }}</h5>
@@ -259,9 +259,9 @@ w3.css
             <div class="corner corner-bl"></div>
             <div class="corner corner-br"></div>
             
-            {% if Entry %}
+            {% if entries %}
             <ul class="w3-ul w3-hoverable" style="margin:0;">
-                {% for entry in Entry %}
+                {% for entry in entries %}
                 <li class="entry-item w3-padding-16 journal-lines">
                     <a href="{% url 'entries:view_entry' entry.id %}" class="w3-row" style="text-decoration:none; color: inherit;">
                         <div class="w3-col s10 m10">

--- a/user/templates/home.html
+++ b/user/templates/home.html
@@ -18,7 +18,7 @@
 {% endif %}
 
 <ul>
-    {% for entry in Entry %}
+    {% for entry in entries %}
     <li>
         <a href="{% url 'entries:view_entry' entry.id %}">{{ entry.title }}</a>
         ({{ entry.created_at }})

--- a/user/views.py
+++ b/user/views.py
@@ -5,13 +5,15 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.decorators import login_required
 from django.views.generic import CreateView
 from django.urls import reverse_lazy
+from entries.models import Entry
 
 
 # Home view
 @login_required(login_url='user:login')
 class HomeView:
     def get(self, request):
-        return render(request, 'home.html')
+        entries = Entry.objects.filter(user=request.user).order_by('-created_at')
+        return render(request, 'home.html', {'entries': entries})
     
 # Login view
 class LoginView:


### PR DESCRIPTION
## Summary
- update the home templates to reference the `entries` context key instead of the incorrect `Entry`
- ensure the user home view passes the current user's entries to its template

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68d05aca12688321921075b0b54edbf5

## Summary by Sourcery

Fix incorrect entry context references in home templates and ensure HomeView supplies the current user's entries to the templates

Bug Fixes:
- Update home templates to iterate over the entries context variable instead of the undefined Entry
- Modify HomeView to query and pass the current user's entries to its template