### PR TITLE
Restrict home view to user entries

### DIFF
--- a/entries/templates/entries/home.html
+++ b/entries/templates/entries/home.html
@@ -259,9 +259,14 @@ w3.css
             <div class="corner corner-bl"></div>
             <div class="corner corner-br"></div>
             
-            {% if Entry %}
+            {% if entries %}
+            <div class="w3-padding-large journal-lines" style="padding-left: 50px !important;">
+                <p class="w3-large text-secondary" style="margin: 0 0 10px 0;">
+                    We're glad to see you back. Here's what you've been writing lately:
+                </p>
+            </div>
             <ul class="w3-ul w3-hoverable" style="margin:0;">
-                {% for entry in Entry %}
+                {% for entry in entries %}
                 <li class="entry-item w3-padding-16 journal-lines">
                     <a href="{% url 'entries:view_entry' entry.id %}" class="w3-row" style="text-decoration:none; color: inherit;">
                         <div class="w3-col s10 m10">

--- a/entries/views.py
+++ b/entries/views.py
@@ -8,7 +8,7 @@ from .forms import EntryForm, MultiDeleteForm, SearchForm
 from .models import Entry
 
 # Entry view
-@login_required
+@login_required(login_url='user:login')
 def home(request):
     entries = Entry.objects.filter(user=request.user).order_by('-created_at')[:5]
     return render(request, 'entries/home.html', {'entries': entries})


### PR DESCRIPTION
## Summary
- require authentication for the personalized home page by redirecting anonymous users to the login view
- scope the home page entry list to the current user's five most recent entries
- update the home template to use the filtered queryset and show a welcome back message for returning users while keeping onboarding copy for newcomers

## Testing
- `python manage.py test entries` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68d05acc95848321b080f11104f5c166

## Summary by Sourcery

Restrict the home view to authenticated users, scope displayed entries to the user's most recent five, and personalize the home template with a conditional greeting.

New Features:
- Require login to access the home view and redirect anonymous users to the login page

Enhancements:
- Limit the home page entry list to the current user's five most recent entries
- Update the home template to use the filtered entries and display a personalized welcome-back message for returning users